### PR TITLE
DM-34926: Migrate to Catch2 v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM lsstts/develop-env:c0024.007
+FROM lsstts/develop-env:c0025.005
 
 USER root
-RUN yum -y install catch-devel boost169-devel make readline-devel
-
+RUN chmod a+rwX -R /home/saluser/
 USER saluser
 
 ARG XML_BRANCH
@@ -22,6 +21,6 @@ RUN chmod a+rwX -R /home/saluser/
 USER saluser
 
 RUN source .setup.sh \
-    && conda install -y readline yaml-cpp boost-cpp
+    && mamba install -y readline yaml-cpp boost-cpp catch2
 
 SHELL ["/bin/bash", "-lc"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,6 @@ node {
                     source $SALUSER_HOME/.setup_salobj.sh
     
                     export PATH=\$CONDA_PREFIX/bin:$PATH
-                    export PKG_CONFIG_PATH="\$CONDA_PREFIX/lib/pkgconfig"
                     cd $WORKSPACE/ts_cRIOcpp
                     make
     

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ deploy: M1M3ThermalCsC
 	@echo '[SCP] Bitfiles/NiFpga_ts_M1M3ThermalFPGA.lvbitx
 	${co}scp Bitfiles/NiFpga_ts_M1M3ThermalFPGA.lvbitx admin@${CRIO_IP}:Bitfiles
 
-tests: tests/Makefile tests/*.cpp
+tests: tests/Makefile tests/*.cpp src/libM1M3TS.a
 	@${MAKE} -C tests
 
 run_tests: tests

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,12 +9,14 @@ CFLAGS += ${SAL_CPPFLAGS} \
 	-DVERSION="\"$(VERSION)\""
 
 C_SRCS = $(shell find LSST NiFpga -name '*.c')
-CPP_SRCS = $(shell find LSST NiFpga -name '*.cpp') ts-M1M3thermald.cpp m1m3tscli.cpp
+LIB_CPP_SRCS = $(shell find LSST NiFpga -name '*.cpp') 
+ALL_CPP_SRCS = $(LIB_CPP_SRCS) $(shell ls *.cpp)
 
-OBJS = $(patsubst %.c,%.c.o,$(C_SRCS)) $(patsubst %.cpp,%.cpp.o,$(CPP_SRCS))
+LIB_OBJS = $(patsubst %.c,%.c.o,$(C_SRCS)) $(patsubst %.cpp,%.cpp.o,$(LIB_CPP_SRCS))
+ALL_OBJS = $(patsubst %.c,%.c.o,$(C_SRCS)) $(patsubst %.cpp,%.cpp.o,$(ALL_CPP_SRCS))
 
 C_DEPS = $(patsubst %.c,%.c.d,$(C_SRCS))
-CPP_DEPS = $(patsubst %.cpp,%.cpp.d,$(CPP_SRCS))
+CPP_DEPS = $(patsubst %.cpp,%.cpp.d,$(ALL_CPP_SRCS))
 
 .PRECIOUS: *.d
 
@@ -22,12 +24,12 @@ ifneq ($(MAKECMDGOALS),clean)
   -include ${C_DEPS} ${CPP_DEPS}
 endif
 
-libM1M3TS.a: $(OBJS)
+libM1M3TS.a: $(LIB_OBJS)
 	@echo '[AR ] $@'
 	${co}$(AR) rs $@ $^
 
 clean:
-	@$(foreach file,$(OBJS) $(C_DEPS) $(CPP_DEPS) libM1M3TS.a $(shell find -name '*.d'), echo '[RM ] ${file}'; $(RM) -r $(file);)
+	@$(foreach file,$(ALL_OBJS) $(C_DEPS) $(CPP_DEPS) libM1M3TS.a $(shell find -name '*.d'), echo '[RM ] ${file}'; $(RM) -r $(file);)
 
 clang-format:
 	@$(foreach file,$(shell find LSST -name '*.cpp' -o -name '*.h'), echo '[FRM] ${file}'; clang-format -i $(file);)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,10 @@ endif
 M1M3_CPPFLAGS := -I"/usr/include" \
 	-I"../src/NiFpga" \
 	-I"../src/LSST/M1M3/TS" \
-	-I"../${CRIO_DIR}/include"
+	-I"../${CRIO_DIR}/include" \
+	$(shell pkg-config catch2-with-main --cflags)
+
+LIBS += $(shell pkg-config catch2-with-main --libs)
 
 compile: $(BINARIES)
 
@@ -43,4 +46,4 @@ clean:
 
 ${BINARIES}: %: %.cpp.o ../src/libM1M3TS.a
 	@echo '[TPP] $<'
-	${co}$(CPP) -o $@ $(LIBS_FLAGS) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(LIBS) $(SAL_LIBS) $(M1M3_CPPFLAGS) $^ ../$(CRIO_DIR)/lib/libcRIOcpp.a ${SAL_WORK_DIR}/lib/libSAL_MTM1M3TS.a
+	${co}$(CPP) -o $@ $(LIBS_FLAGS) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(SAL_LIBS) $(M1M3_CPPFLAGS) $^ $(LIBS) ../$(CRIO_DIR)/lib/libcRIOcpp.a ${SAL_WORK_DIR}/lib/libSAL_MTM1M3TS.a

--- a/tests/test_MixingValveSettings.cpp
+++ b/tests/test_MixingValveSettings.cpp
@@ -20,12 +20,13 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#define CATCH_CONFIG_MAIN
-#include <catch/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <Settings/MixingValve.h>
 
 using namespace LSST::M1M3::TS::Settings;
+using Catch::Approx;
 
 TEST_CASE("Test conversions", "[MixingValveSettings]") {
     REQUIRE_NOTHROW(MixingValve::instance().load("data/MixingValve.yaml"));

--- a/tests/test_SimulatedFPGA.cpp
+++ b/tests/test_SimulatedFPGA.cpp
@@ -20,8 +20,7 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#define CATCH_CONFIG_MAIN
-#include <catch/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <SimulatedFPGA.h>
 #include <cRIO/ThermalILC.h>


### PR DESCRIPTION
- Temperature telemetry
- simulate temperatures
- Migrated to Catch2 v3+
