### PR TITLE
Use MPU runLoop, paraller operations on FlowMeter and VFD

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Check Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Changelog check
         uses: Zomzog/changelog-checker@v1.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN source ~/.crio_setup.sh && cd $TS_XML_DIR \
 
 FROM crio-develop
 
-ARG cRIO_CPP=v1.9.0
+ARG cRIO_CPP=v1.10.0
 ARG M1M3_SUPPORT=develop
 ARG TARGET=simulator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN source ~/.crio_setup.sh && cd $TS_XML_DIR \
 
 FROM crio-develop
 
-ARG cRIO_CPP=v1.7.0
+ARG cRIO_CPP=v1.9.0
 ARG M1M3_SUPPORT=develop
 ARG TARGET=simulator
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ properties(
 node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
-    def SAME_CRIO_BRANCH = ["main", "tickets/DM-40800"]
+    def SAME_CRIO_BRANCH = ["main", "tickets/DM-41336"]
 
     stage('Cloning sources')
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ node {
     
                     cd $WORKSPACE/ts_m1m3thermal
                     LIBS_FLAGS="-L\$CONDA_PREFIX/lib" make simulator
-                    make junit
+                    LSST_DDS_PARTITION_PREFIX=test make junit
                  """
              }
         }

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ m1m3tscli: src/m1m3tscli.cpp.o src/libM1M3TS.a
 
 # Other Targets
 clean:
-	@$(foreach file,M1M3ThermalCsC src/m1m3thermalcsc.cpp.o doc, echo '[RM ] ${file}'; $(RM) -r $(file);)
+	@$(foreach file,M1M3ThermalCsC src/m1m3thermalcsc.cpp.o, echo '[RM ] ${file}'; $(RM) -r $(file);)
 	@$(foreach dir,src tests,$(MAKE) -C ${dir} $@;)
 
 # file targets

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -4,7 +4,7 @@ ifndef VERBOSE
   silence := --silence-errors
 endif
 
-c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE -DSPDLOG_FMT_EXTERNAL
+c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE # -DSPDLOG_FMT_EXTERNAL
 
 ifdef DEBUG
   c_opts += -g
@@ -34,6 +34,7 @@ CRIO_CFLAGS := -I${CRIO_DIR}/include
 PKG_LIBS := $(shell pkg-config yaml-cpp --libs $(silence)) \
 	$(shell pkg-config spdlog --libs $(silence)) \
 	$(shell pkg-config fmt --libs $(silence)) \
+	-lreadline
 
 ifdef SIMULATOR
   LIBS := $(PKG_LIBS) -ldl ${SAL_WORK_DIR}/lib/libSAL_MTM1M3TS.a -ldcpssacpp -ldcpsgapi -lddsuser -lddskernel -lpthread -lddsserialization -lddsconfparser -lddsconf -lddsdatabase -lddsutil -lddsos

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -4,7 +4,7 @@ ifndef VERBOSE
   silence := --silence-errors
 endif
 
-c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE -DSPDLOG_FMT_EXTERNAL
 
 ifdef DEBUG
   c_opts += -g
@@ -22,14 +22,18 @@ else
   CPP := g++ -std=c++14 -Wall -fmessage-length=0 ${c_opts} -ldl -lpthread
 endif
 
-PKG_CPPFLAGS := $(shell pkg-config yaml-cpp --cflags $(silence)) $(shell pkg-config spdlog --cflags $(silence))
+PKG_CPPFLAGS := $(shell pkg-config yaml-cpp --cflags $(silence)) \
+	$(shell pkg-config spdlog --cflags $(silence)) \
+	$(shell pkg-config fmt --cflags $(silence))
 
 SAL_CPPFLAGS += $(PKG_CPPFLAGS) -I${OSPL_HOME}/include -I${OSPL_HOME}/include/sys -I${OSPL_HOME}/include/dcps/C++/SACPP -I${SAL_WORK_DIR}/MTM1M3TS/cpp/src -I${SAL_WORK_DIR}/include -I${SAL_HOME}/include -I${LSST_SDK_INSTALL}/include
 
 CRIO_DIR ?= ../ts_cRIOcpp
 CRIO_CFLAGS := -I${CRIO_DIR}/include
 
-PKG_LIBS := $(shell pkg-config yaml-cpp --libs $(silence)) $(shell pkg-config spdlog --libs $(silence))
+PKG_LIBS := $(shell pkg-config yaml-cpp --libs $(silence)) \
+	$(shell pkg-config spdlog --libs $(silence)) \
+	$(shell pkg-config fmt --libs $(silence)) \
 
 ifdef SIMULATOR
   LIBS := $(PKG_LIBS) -ldl ${SAL_WORK_DIR}/lib/libSAL_MTM1M3TS.a -ldcpssacpp -ldcpsgapi -lddsuser -lddskernel -lpthread -lddsserialization -lddsconfparser -lddsconf -lddsdatabase -lddsutil -lddsos

--- a/SettingFiles/Sets/Default/1/FCU.yaml
+++ b/SettingFiles/Sets/Default/1/FCU.yaml
@@ -1,1 +1,0 @@
-DisabledFCU: []

--- a/SettingFiles/Sets/Default/1/MixingValve.yaml
+++ b/SettingFiles/Sets/Default/1/MixingValve.yaml
@@ -1,9 +1,0 @@
-# units are mA (milliamperes)
-Commanding:
-  FullyClosed: 4
-  FullyOpened: 20
-
-# units are V (Volts)
-PositionFeedback:
-  FullyClosed: 0.03
-  FullyOpened: 9.64

--- a/SettingFiles/v1/_init.yaml
+++ b/SettingFiles/v1/_init.yaml
@@ -1,4 +1,13 @@
-DisabledFCU: []
+FCU:
+  AutoDisable: true
+  FailuresToDisable: 3
+  Disabled: []
+
+FlowMeter:
+  Enabled: true
+
+GlycolPump:
+  Enabled: true
 
 MixingValve:
   # units are mA (milliamperes)
@@ -10,9 +19,3 @@ MixingValve:
   PositionFeedback:
     FullyClosed: 0.03
     FullyOpened: 9.64
-
-FlowMeter:
-  Enabled: true
-
-GlycoolPump:
-  Enabled: true

--- a/SettingFiles/v1/_init.yaml
+++ b/SettingFiles/v1/_init.yaml
@@ -1,0 +1,18 @@
+DisabledFCU: []
+
+MixingValve:
+  # units are mA (milliamperes)
+  Commanding:
+    FullyClosed: 4
+    FullyOpened: 20
+  
+  # units are V (Volts)
+  PositionFeedback:
+    FullyClosed: 0.03
+    FullyOpened: 9.64
+
+FlowMeter:
+  Enabled: true
+
+GlycoolPump:
+  Enabled: true

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -1,0 +1,10 @@
+.. _Version_History:
+
+===============
+Version History
+===============
+
+v0.1.0
+=======
+
+* Basic functionality - FCU communication, FlowMeter and Glycol Pump telemetry & commands

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -161,13 +161,13 @@ void SAL_coolantPumpPower::execute() {
 }
 
 void SAL_coolantPumpStart::execute() {
-    IFPGA::get().vfd->start();
+    IFPGA::get().next_vfd->start();
     ackComplete();
     SPDLOG_INFO("Glycol coolant pump started");
 }
 
 void SAL_coolantPumpStop::execute() {
-    IFPGA::get().vfd->stop();
+    IFPGA::get().next_vfd->stop();
     ackComplete();
     SPDLOG_INFO("Glycol coolant pump stopped");
 }
@@ -181,13 +181,13 @@ bool SAL_coolantPumpFrequency::validate() {
 }
 
 void SAL_coolantPumpFrequency::execute() {
-    IFPGA::get().vfd->setFrequency(params.targetFrequency);
+    IFPGA::get().next_vfd->setFrequency(params.targetFrequency);
     ackComplete();
     SPDLOG_INFO("Changed coolant pump target frequency to {:0.02f} Hz", params.targetFrequency);
 }
 
 void SAL_coolantPumpReset::execute() {
-    IFPGA::get().vfd->reset();
+    IFPGA::get().next_vfd->resetCommand();
     ackComplete();
     SPDLOG_INFO("Coolant pump reseted");
 }

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -27,12 +27,13 @@
 #include <cRIO/ControllerThread.h>
 
 #include <Commands/SAL.h>
-#include <Events/SummaryState.h>
 #include <Events/EngineeringMode.h>
+#include <Events/SummaryState.h>
 #include <Events/ThermalInfo.h>
-#include <Settings/MixingValve.h>
 #include <Settings/Controller.h>
+#include <Settings/MixingValve.h>
 #include <TSApplication.h>
+#include <TSPublisher.h>
 
 using namespace LSST::cRIO;
 using namespace LSST::M1M3::TS;
@@ -48,9 +49,12 @@ void changeAllILCsMode(uint16_t mode) {
 }
 
 bool SAL_start::validate() {
-    // TODO needs new, single file config
     if (params.configurationOverride.empty()) {
         params.configurationOverride = "Default";
+    }
+    if (params.configurationOverride[0] == '_') {
+        SPDLOG_ERROR("configurationOverride argument shall not start with _");
+        return false;
     }
     return true;
 }

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -31,6 +31,7 @@
 #include <Events/SummaryState.h>
 #include <Events/ThermalInfo.h>
 #include <Settings/Controller.h>
+#include <Settings/GlycolPump.h>
 #include <Settings/MixingValve.h>
 #include <TSApplication.h>
 #include <TSPublisher.h>
@@ -63,6 +64,11 @@ void SAL_start::execute() {
     SPDLOG_INFO("Starting, settings={}", params.configurationOverride);
     Settings::Controller::instance().load(params.configurationOverride);
 
+    if (Settings::GlycolPump::instance().enabled) {
+        IFPGA::get().setCoolantPumpPower(true);
+        SPDLOG_INFO("Glycol pump turned on.");
+    }
+
     changeAllILCsMode(ILC::ILCMode::Disabled);
 
     TSApplication::ilc()->clear();
@@ -90,6 +96,7 @@ void SAL_enable::execute() {
 void SAL_disable::execute() {
     changeAllILCsMode(ILC::ILCMode::Disabled);
     IFPGA::get().setFCUPower(false);
+    IFPGA::get().setCoolantPumpPower(false);
 
     Events::SummaryState::setState(MTM1M3TS_shared_SummaryStates_DisabledState);
     ackComplete();

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -161,13 +161,13 @@ void SAL_coolantPumpPower::execute() {
 }
 
 void SAL_coolantPumpStart::execute() {
-    IFPGA::get().coolantPumpStartStop(true);
+    IFPGA::get().vfd->start();
     ackComplete();
     SPDLOG_INFO("Glycol coolant pump started");
 }
 
 void SAL_coolantPumpStop::execute() {
-    IFPGA::get().coolantPumpStartStop(false);
+    IFPGA::get().vfd->stop();
     ackComplete();
     SPDLOG_INFO("Glycol coolant pump stopped");
 }
@@ -181,13 +181,13 @@ bool SAL_coolantPumpFrequency::validate() {
 }
 
 void SAL_coolantPumpFrequency::execute() {
-    IFPGA::get().setCoolantPumpFrequency(params.targetFrequency);
+    IFPGA::get().vfd->setFrequency(params.targetFrequency);
     ackComplete();
     SPDLOG_INFO("Changed coolant pump target frequency to {:0.02f} Hz", params.targetFrequency);
 }
 
 void SAL_coolantPumpReset::execute() {
-    IFPGA::get().coolantPumpReset();
+    IFPGA::get().vfd->reset();
     ackComplete();
     SPDLOG_INFO("Coolant pump reseted");
 }

--- a/src/LSST/M1M3/TS/Commands/SAL.h
+++ b/src/LSST/M1M3/TS/Commands/SAL.h
@@ -23,10 +23,11 @@
 #ifndef _TS_Command_SAL
 #define _TS_Command_SAL
 
-#include <TSPublisher.h>
 #include <SAL_MTM1M3TS.h>
 
 #include <cRIO/SAL/Command.h>
+
+#include <TSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -106,18 +106,24 @@ void Update::_sendFCU() {
 
 void Update::_sendFlowMeter() {
     try {
-        IFPGA::get().flowMeter->runLoop(IFPGA::get());
+        bool finished = IFPGA::get().flowMeter->runLoop(IFPGA::get());
+        if (finished) {
+            IFPGA::get().setNextFlowMeter();
+        }
     } catch (std::exception &e) {
         SPDLOG_WARN("Cannot poll Flow Meter: {}", e.what());
-        IFPGA::get().flowMeter->clearCommanded();
+        IFPGA::get().setNextFlowMeter();
     }
 }
 
 void Update::_sendVFD() {
     try {
-        IFPGA::get().vfd->runLoop(IFPGA::get());
+        bool finished = IFPGA::get().vfd->runLoop(IFPGA::get());
+        if (finished) {
+            IFPGA::get().setNextVFD();
+        }
     } catch (std::exception &e) {
         SPDLOG_WARN("Cannot poll VFD: {}", e.what());
-        IFPGA::get().vfd->clearCommanded();
+        IFPGA::get().setNextVFD();
     }
 }

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -25,17 +25,21 @@
 #include <cRIO/ThermalILC.h>
 
 #include "Commands/Update.h"
-#include "TSApplication.h"
 
 #include "Events/EnabledILC.h"
+#include "Events/GlycolPumpStatus.h"
 #include "Events/Heartbeat.h"
 #include "Events/SummaryState.h"
+
+#include "Settings/FlowMeter.h"
+#include "Settings/GlycolPump.h"
 
 #include "Telemetry/VFDSAL.h"
 #include "Telemetry/GlycolLoopTemperature.h"
 #include "Telemetry/MixingValve.h"
 #include "Telemetry/ThermalData.h"
-#include "Events/GlycolPumpStatus.h"
+
+#include "TSApplication.h"
 
 using namespace LSST::M1M3::TS::Commands;
 
@@ -51,8 +55,13 @@ void Update::execute() {
 
     Events::Heartbeat::instance().tryToggle();
 
-    _sendFlowMeter();
-    _sendVFD();
+    if (Settings::FlowMeter::instance().enabled) {
+        _sendFlowMeter();
+    }
+
+    if (Settings::GlycolPump::instance().enabled) {
+        _sendVFD();
+    }
 
     SPDLOG_TRACE("Commands::Update leaving execute");
 }

--- a/src/LSST/M1M3/TS/Events/EnabledILC.h
+++ b/src/LSST/M1M3/TS/Events/EnabledILC.h
@@ -36,6 +36,11 @@ public:
     EnabledILC(token);
 
     /**
+     * Clears failed ILC counts.
+     */
+    void reset();
+
+    /**
      * Enabled / disable ILC.
      */
     void setEnabled(uint8_t ilc, bool newState);
@@ -43,9 +48,19 @@ public:
     bool isEnabled(uint8_t ilc);
 
     /**
+     * Called when an ILC experienced communication problem. Auto disable ILC
+     * if communication errors cross a counter.
+     */
+    void communicationProblem(uint8_t ilc);
+
+    /**
      * Sends updates through SAL/DDS.
      */
     void send();
+
+    // TODO move to SAL/DDS
+    int errorCount[cRIO::NUM_TS_ILC];
+    bool autoDisabled[cRIO::NUM_TS_ILC];
 
 private:
     bool _updated;

--- a/src/LSST/M1M3/TS/IFPGA.cpp
+++ b/src/LSST/M1M3/TS/IFPGA.cpp
@@ -48,12 +48,24 @@ IFPGA& IFPGA::get() {
 #endif
 }
 
-void IFPGA::setMPUs(std::shared_ptr<VFD> _vfd, std::shared_ptr<FlowMeter> _flowMeter) {
-    vfd = _vfd;
-    vfd->setLoopTimeOut(1000ms);
+void IFPGA::setMPUFactory(std::shared_ptr<FactoryInterface> _factory) {
+    mpuFactory = _factory;
 
-    flowMeter = _flowMeter;
-    flowMeter->setLoopTimeOut(2000ms);
+    flowMeter = mpuFactory->createFlowMeter();
+    next_flowMeter = mpuFactory->createFlowMeter();
+
+    vfd = mpuFactory->createVFD();
+    next_vfd = mpuFactory->createVFD();
+}
+
+void IFPGA::setNextFlowMeter() {
+    flowMeter = next_flowMeter;
+    next_flowMeter = mpuFactory->createFlowMeter();
+}
+
+void IFPGA::setNextVFD() {
+    vfd = next_vfd;
+    next_vfd = mpuFactory->createVFD();
 }
 
 float IFPGA::getMixingValvePosition() {

--- a/src/LSST/M1M3/TS/IFPGA.cpp
+++ b/src/LSST/M1M3/TS/IFPGA.cpp
@@ -93,24 +93,6 @@ void IFPGA::setCoolantPumpPower(bool on) {
     writeCommandFIFO(buf, 2, 10);
 }
 
-void IFPGA::coolantPumpStartStop(bool start) {
-    vfd->clearCommanded();
-    vfd->presetHoldingRegister(0x2000, start ? 0x1a : 0x01);
-    mpuCommands(*vfd);
-}
-
-void IFPGA::coolantPumpReset() {
-    vfd->clearCommanded();
-    vfd->presetHoldingRegister(0x2000, 0x08);
-    mpuCommands(*vfd);
-}
-
-void IFPGA::setCoolantPumpFrequency(float freq) {
-    vfd->clearCommanded();
-    vfd->presetHoldingRegister(0x2001, freq * 100.0f);
-    mpuCommands(*vfd);
-}
-
 void IFPGA::setHeartbeat(bool heartbeat) {
     uint16_t buf[2];
     buf[0] = FPGAAddress::HEARTBEAT;

--- a/src/LSST/M1M3/TS/IFPGA.h
+++ b/src/LSST/M1M3/TS/IFPGA.h
@@ -31,6 +31,7 @@
 #include <cRIO/MPU.h>
 #include <cRIO/MPUTelemetry.h>
 
+#include <MPU/FactoryInterface.h>
 #include <MPU/FlowMeter.h>
 #include <MPU/VFD.h>
 
@@ -60,7 +61,13 @@ public:
     IFPGA();
     virtual ~IFPGA() {}
 
-    void setMPUs(std::shared_ptr<VFD> vfd, std::shared_ptr<FlowMeter> flowMeter);
+    void setMPUFactory(std::shared_ptr<FactoryInterface> _factory);
+
+    /**
+     * Switch to use next flow meter.
+     */
+    void setNextFlowMeter();
+    void setNextVFD();
 
     static IFPGA& get();
 
@@ -85,8 +92,10 @@ public:
 
     virtual LSST::cRIO::MPUTelemetry readMPUTelemetry(LSST::cRIO::MPU& mpu) = 0;
 
-    std::shared_ptr<VFD> vfd;
-    std::shared_ptr<FlowMeter> flowMeter;
+    std::shared_ptr<FactoryInterface> mpuFactory;
+
+    std::shared_ptr<VFD> vfd, next_vfd;
+    std::shared_ptr<FlowMeter> flowMeter, next_flowMeter;
 
 protected:
     virtual void processMPUResponse(LSST::cRIO::MPU& mpu, uint8_t* data, uint16_t len);

--- a/src/LSST/M1M3/TS/IFPGA.h
+++ b/src/LSST/M1M3/TS/IFPGA.h
@@ -81,10 +81,6 @@ public:
     void setFCUPower(bool on);
     void setCoolantPumpPower(bool on);
 
-    void coolantPumpStartStop(bool start);
-    void coolantPumpReset();
-    void setCoolantPumpFrequency(float freq);
-
     void setHeartbeat(bool heartbeat);
 
     virtual LSST::cRIO::MPUTelemetry readMPUTelemetry(LSST::cRIO::MPU& mpu) = 0;

--- a/src/LSST/M1M3/TS/MPU/FactoryInterface.h
+++ b/src/LSST/M1M3/TS/MPU/FactoryInterface.h
@@ -1,5 +1,5 @@
 /*
- * FlowMeter MPU
+ * Interface for factory creating application specific MPU objects.
  *
  * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
  * This product includes software developed by the Vera C.Rubin Observatory Project
@@ -20,44 +20,29 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef __TS_MPU_FLOWMETER__
-#define __TS_MPU_FLOWMETER__
+#ifndef __TS_MPU_FactoryInterface__
+#define __TS_MPU_FactoryInterface__
 
-#include <cRIO/MPU.h>
+#include <memory>
+
+#include "FlowMeter.h"
+#include "VFD.h"
 
 namespace LSST {
 namespace M1M3 {
 namespace TS {
 
 /**
- * Reads FlowMeter values.
+ * Contains methods to create application specific MPU objects.
  */
-class FlowMeter : public cRIO::MPU {
+class FactoryInterface {
 public:
-    FlowMeter(uint8_t bus, uint8_t mpu_address) : MPU(bus, mpu_address) { setLoopTimeOut(1000ms); }
-
-    void loopWrite() override;
-
-    uint16_t getSignalStrength() { return getRegister(5500); }
-    double getFlowRate() { return _getFloatValue(1000); }
-    double getNetTotalizer() { return _getFloatValue(2500); }
-    double getPositiveTotalizer() { return _getFloatValue(2502); }
-    double getNegativeTotalizer() { return _getFloatValue(2504); }
-
-private:
-    float _getFloatValue(uint16_t reg);
-    double _getDoubleValue(uint16_t reg);
-};
-
-class FlowMeterPrint : public FlowMeter {
-public:
-    FlowMeterPrint(uint8_t bus, uint8_t mpu_address) : FlowMeter(bus, mpu_address) {}
-
-    void loopRead(bool timedout) override;
+    virtual std::shared_ptr<FlowMeter> createFlowMeter() = 0;
+    virtual std::shared_ptr<VFD> createVFD() = 0;
 };
 
 }  // namespace TS
 }  // namespace M1M3
 }  // namespace LSST
 
-#endif /* __TS_MPU_FLOWMETER__ */
+#endif /* __TS_MPU_FactoryInterface__ */

--- a/src/LSST/M1M3/TS/MPU/VFD.h
+++ b/src/LSST/M1M3/TS/MPU/VFD.h
@@ -40,6 +40,11 @@ public:
 
     void loopWrite() override;
 
+    void start() { presetHoldingRegister(0x2000, 0x1a); }
+    void stop() { presetHoldingRegister(0x2000, 0x01); }
+    void reset() { presetHoldingRegister(0x2000, 0x08); }
+    void setFrequency(float freq) { presetHoldingRegister(0x2001, freq * 100.0f); }
+
     uint16_t getStatus() { return getRegister(0x2000); }
     float getCommandedFrequency() { return getRegister(0x2001) / 100.0f; }
 

--- a/src/LSST/M1M3/TS/MPU/VFD.h
+++ b/src/LSST/M1M3/TS/MPU/VFD.h
@@ -23,7 +23,11 @@
 #ifndef __TS_MPU_VFD__
 #define __TS_MPU_VFD__
 
+#include <chrono>
+
 #include <cRIO/MPU.h>
+
+using namespace std::chrono_literals;
 
 namespace LSST {
 namespace M1M3 {
@@ -36,13 +40,13 @@ namespace TS {
  */
 class VFD : public cRIO::MPU {
 public:
-    VFD(uint8_t bus, uint8_t mpu_address) : MPU(bus, mpu_address) {}
+    VFD(uint8_t bus, uint8_t mpu_address) : MPU(bus, mpu_address) { setLoopTimeOut(2000ms); }
 
     void loopWrite() override;
 
     void start() { presetHoldingRegister(0x2000, 0x1a); }
     void stop() { presetHoldingRegister(0x2000, 0x01); }
-    void reset() { presetHoldingRegister(0x2000, 0x08); }
+    void resetCommand() { presetHoldingRegister(0x2000, 0x08); }
     void setFrequency(float freq) { presetHoldingRegister(0x2001, freq * 100.0f); }
 
     uint16_t getStatus() { return getRegister(0x2000); }

--- a/src/LSST/M1M3/TS/SALThermalILC.cpp
+++ b/src/LSST/M1M3/TS/SALThermalILC.cpp
@@ -21,10 +21,13 @@
  */
 
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 
 #include <SALThermalILC.h>
 
 #include <Events/ThermalInfo.h>
+#include <Events/EnabledILC.h>
+#include <Settings/Thermal.h>
 #include <Telemetry/ThermalData.h>
 
 namespace LSST {
@@ -32,6 +35,14 @@ namespace M1M3 {
 namespace TS {
 
 SALThermalILC::SALThermalILC(std::shared_ptr<SAL_MTM1M3TS> m1m3tsSAL) : _m1m3tsSAL(m1m3tsSAL) {}
+
+void SALThermalILC::handleMissingReply(uint8_t address, uint8_t func) {
+    if (Settings::Thermal::instance().autoDisable) {
+        Events::EnabledILC::instance().communicationProblem(_address2ILCIndex(address));
+    } else {
+        cRIO::ThermalILC::handleMissingReply(address, func);
+    }
+}
 
 void SALThermalILC::preProcess() {}
 
@@ -53,7 +64,7 @@ void SALThermalILC::processChangeILCMode(uint8_t address, uint16_t mode) {}
 
 void SALThermalILC::processSetTempILCAddress(uint8_t address, uint8_t newAddress) {}
 
-void SALThermalILC::processResetServer(uint8_t address) {}
+void SALThermalILC::processResetServer(uint8_t address) { SPDLOG_DEBUG("ILC {} server reset.", address); }
 
 void SALThermalILC::processThermalStatus(uint8_t address, uint8_t status, float differentialTemperature,
                                          uint8_t fanRPM, float absoluteTemperature) {

--- a/src/LSST/M1M3/TS/SALThermalILC.h
+++ b/src/LSST/M1M3/TS/SALThermalILC.h
@@ -40,6 +40,8 @@ public:
     SALThermalILC(std::shared_ptr<SAL_MTM1M3TS> m1m3tsSAL);
 
 protected:
+    void handleMissingReply(uint8_t address, uint8_t func) override;
+
     void preProcess() override;
     void postProcess() override;
 

--- a/src/LSST/M1M3/TS/Settings/Controller.h
+++ b/src/LSST/M1M3/TS/Settings/Controller.h
@@ -26,7 +26,6 @@
 
 #include <cRIO/Singleton.h>
 #include <cRIO/Settings/Path.h>
-#include <cRIO/Settings/Alias.h>
 
 #include <Settings/MixingValve.h>
 #include <Settings/Thermal.h>
@@ -44,16 +43,8 @@ public:
     Controller(token) {}
 
     void load(const std::string& label) {
-        _aliases.load(cRIO::Settings::Path::getFilePath("Base/AliasApplicationSettings.yaml"));
-
-        std::string settingsRoot = cRIO::Settings::Path::getFilePath(_aliases.getPath(label));
-
-        MixingValve::instance().load(settingsRoot + "/MixingValve.yaml");
-        Thermal::instance().load(settingsRoot + "/FCU.yaml");
+        Thermal::instance().load(cRIO::Settings::Path::getFilePath("v1/_init.yaml"));
     }
-
-private:
-    cRIO::Settings::Alias _aliases;
 };
 
 }  // namespace Settings

--- a/src/LSST/M1M3/TS/Settings/FlowMeter.cpp
+++ b/src/LSST/M1M3/TS/Settings/FlowMeter.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of LSST M1M3 thermal system package.
  *
- * Developed for the LSST Data Management System.
+ * Developed for the Vera C. Rubin Telescope and Site System.
  * This product includes software developed by the LSST Project
  * (https://www.lsst.org).
  * See the COPYRIGHT file at the top-level directory of this distribution
@@ -21,30 +21,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _TS_Settings_Controller_h
-#define _TS_Settings_Controller_h
+#include <spdlog/spdlog.h>
 
-#include <cRIO/Singleton.h>
-#include <cRIO/Settings/Path.h>
+#include <Settings/FlowMeter.h>
 
-namespace LSST {
-namespace M1M3 {
-namespace TS {
-namespace Settings {
+using namespace LSST::M1M3::TS::Settings;
 
-/**
- * Settings controller. Loads all application settings from YAML file.
- */
-class Controller : public cRIO::Singleton<Controller> {
-public:
-    Controller(token) {}
+FlowMeter::FlowMeter(token) { enabled = false; }
 
-    void load(const std::string& label);
-};
+void FlowMeter::load(YAML::Node doc) {
+    SPDLOG_TRACE("Loading flow meter settings");
 
-}  // namespace Settings
-}  // namespace TS
-}  // namespace M1M3
-}  // namespace LSST
-
-#endif  // !_TS_Settings_Controller_h
+    enabled = doc["Enabled"].as<bool>();
+}

--- a/src/LSST/M1M3/TS/Settings/FlowMeter.h
+++ b/src/LSST/M1M3/TS/Settings/FlowMeter.h
@@ -21,25 +21,26 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _TS_Settings_Controller_h
-#define _TS_Settings_Controller_h
+#ifndef _TS_Settings_FlowMeter_h
+#define _TS_Settings_FlowMeter_h
+
+#include <yaml-cpp/yaml.h>
 
 #include <cRIO/Singleton.h>
-#include <cRIO/Settings/Path.h>
+#include <TSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace TS {
 namespace Settings {
 
-/**
- * Settings controller. Loads all application settings from YAML file.
- */
-class Controller : public cRIO::Singleton<Controller> {
+class FlowMeter : public cRIO::Singleton<FlowMeter> {
 public:
-    Controller(token) {}
+    FlowMeter(token);
 
-    void load(const std::string& label);
+    void load(YAML::Node doc);
+
+    bool enabled;
 };
 
 }  // namespace Settings
@@ -47,4 +48,4 @@ public:
 }  // namespace M1M3
 }  // namespace LSST
 
-#endif  // !_TS_Settings_Controller_h
+#endif  //!_TS_Settings_FlowMeter_h

--- a/src/LSST/M1M3/TS/Settings/GlycolPump.cpp
+++ b/src/LSST/M1M3/TS/Settings/GlycolPump.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of LSST M1M3 thermal system package.
  *
- * Developed for the LSST Data Management System.
+ * Developed for the Vera C. Rubin Telescope and Site System.
  * This product includes software developed by the LSST Project
  * (https://www.lsst.org).
  * See the COPYRIGHT file at the top-level directory of this distribution
@@ -21,30 +21,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _TS_Settings_Controller_h
-#define _TS_Settings_Controller_h
+#include <spdlog/spdlog.h>
 
-#include <cRIO/Singleton.h>
-#include <cRIO/Settings/Path.h>
+#include <Settings/GlycolPump.h>
 
-namespace LSST {
-namespace M1M3 {
-namespace TS {
-namespace Settings {
+using namespace LSST::M1M3::TS::Settings;
 
-/**
- * Settings controller. Loads all application settings from YAML file.
- */
-class Controller : public cRIO::Singleton<Controller> {
-public:
-    Controller(token) {}
+GlycolPump::GlycolPump(token) { enabled = false; }
 
-    void load(const std::string& label);
-};
+void GlycolPump::load(YAML::Node doc) {
+    SPDLOG_TRACE("Loading Glycol Pump settings");
 
-}  // namespace Settings
-}  // namespace TS
-}  // namespace M1M3
-}  // namespace LSST
-
-#endif  // !_TS_Settings_Controller_h
+    enabled = doc["Enabled"].as<bool>();
+}

--- a/src/LSST/M1M3/TS/Settings/GlycolPump.h
+++ b/src/LSST/M1M3/TS/Settings/GlycolPump.h
@@ -21,25 +21,28 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _TS_Settings_Controller_h
-#define _TS_Settings_Controller_h
+#ifndef _TS_Settings_GlycolPump_h
+#define _TS_Settings_GlycolPump_h
+
+#include <yaml-cpp/yaml.h>
+
+#include <SAL_MTM1M3TS.h>
 
 #include <cRIO/Singleton.h>
-#include <cRIO/Settings/Path.h>
+#include <TSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace TS {
 namespace Settings {
 
-/**
- * Settings controller. Loads all application settings from YAML file.
- */
-class Controller : public cRIO::Singleton<Controller> {
+class GlycolPump : public cRIO::Singleton<GlycolPump> {
 public:
-    Controller(token) {}
+    GlycolPump(token);
 
-    void load(const std::string& label);
+    void load(YAML::Node doc);
+
+    bool enabled;
 };
 
 }  // namespace Settings
@@ -47,4 +50,4 @@ public:
 }  // namespace M1M3
 }  // namespace LSST
 
-#endif  // !_TS_Settings_Controller_h
+#endif  //!_TS_Settings_GlycolPump_h

--- a/src/LSST/M1M3/TS/Settings/MixingValve.cpp
+++ b/src/LSST/M1M3/TS/Settings/MixingValve.cpp
@@ -35,6 +35,7 @@ MixingValve::MixingValve(token) {
 }
 
 void MixingValve::load(YAML::Node doc) {
+    SPDLOG_TRACE("Loading mixing valve settigns");
     try {
         commandingFullyClosed = doc["Commanding"]["FullyClosed"].as<float>();
         commandingFullyOpened = doc["Commanding"]["FullyOpened"].as<float>();

--- a/src/LSST/M1M3/TS/Settings/MixingValve.cpp
+++ b/src/LSST/M1M3/TS/Settings/MixingValve.cpp
@@ -21,10 +21,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <Settings/MixingValve.h>
-
 #include <spdlog/spdlog.h>
-#include <yaml-cpp/yaml.h>
+
+#include <Settings/MixingValve.h>
 
 using namespace LSST::M1M3::TS::Settings;
 
@@ -35,19 +34,15 @@ MixingValve::MixingValve(token) {
     positionFeedbackFullyOpened = NAN;
 }
 
-void MixingValve::load(const std::string &filename) {
-    SPDLOG_DEBUG("MixingValve::load(\"{}\")", filename);
-
+void MixingValve::load(YAML::Node doc) {
     try {
-        YAML::Node doc = YAML::LoadFile(filename);
-
         commandingFullyClosed = doc["Commanding"]["FullyClosed"].as<float>();
         commandingFullyOpened = doc["Commanding"]["FullyOpened"].as<float>();
 
         positionFeedbackFullyClosed = doc["PositionFeedback"]["FullyClosed"].as<float>();
         positionFeedbackFullyOpened = doc["PositionFeedback"]["FullyOpened"].as<float>();
     } catch (YAML::Exception &ex) {
-        throw std::runtime_error(fmt::format("YAML Loading {}: {}", filename, ex.what()));
+        throw std::runtime_error(fmt::format("Cannot load Mising Valve settings: {}", ex.what()));
     }
 }
 

--- a/src/LSST/M1M3/TS/Settings/MixingValve.h
+++ b/src/LSST/M1M3/TS/Settings/MixingValve.h
@@ -24,6 +24,8 @@
 #ifndef _TS_Settings_MixingValve_h
 #define _TS_Settings_MixingValve_h
 
+#include <yaml-cpp/yaml.h>
+
 #include <SAL_MTM1M3TS.h>
 
 #include <cRIO/Singleton.h>
@@ -38,7 +40,7 @@ class MixingValve : public cRIO::Singleton<MixingValve>, MTM1M3TS_logevent_mixin
 public:
     MixingValve(token);
 
-    void load(const std::string& filename);
+    void load(YAML::Node doc);
 
     void log() { TSPublisher::SAL()->logEvent_mixingValveSettings(this, 0); }
 

--- a/src/LSST/M1M3/TS/Settings/Thermal.cpp
+++ b/src/LSST/M1M3/TS/Settings/Thermal.cpp
@@ -23,34 +23,26 @@
 
 #include <algorithm>
 #include <spdlog/spdlog.h>
-#include <yaml-cpp/yaml.h>
 
 #include <cRIO/ThermalILC.h>
 
 #include <Events/EnabledILC.h>
-#include <Settings/MixingValve.h>
 #include <Settings/Thermal.h>
 
 using namespace LSST::M1M3::TS::Settings;
 
-void Thermal::load(const std::string &filename) {
-    SPDLOG_DEBUG("Thermal::load(\"{}\")", filename);
+void Thermal::load(YAML::Node doc) {
+    SPDLOG_TRACE("Loading disabled FCU list");
 
-    try {
-        YAML::Node doc = YAML::LoadFile(filename);
+    autoDisable = doc["AutoDisable"].as<bool>();
+    failuresToDisable = doc["FailuresToDisable"].as<int>();
 
-        auto disabledIndices = doc["DisabledFCU"].as<std::vector<int>>();
+    auto disabledIndices = doc["Disabled"].as<std::vector<int>>();
 
-        for (int i = 0; i < cRIO::NUM_TS_ILC; i++) {
-            enabledFCU[i] =
-                    std::find(disabledIndices.begin(), disabledIndices.end(), i + 1) == disabledIndices.end();
-            Events::EnabledILC::instance().setEnabled(i, enabledFCU[i]);
-        }
-
-        MixingValve::instance().load(doc["MixingValve"]);
-
-    } catch (YAML::Exception &ex) {
-        throw std::runtime_error(fmt::format("YAML Loading {}: {}", filename, ex.what()));
+    for (int i = 0; i < cRIO::NUM_TS_ILC; i++) {
+        enabledFCU[i] =
+                std::find(disabledIndices.begin(), disabledIndices.end(), i + 1) == disabledIndices.end();
+        Events::EnabledILC::instance().setEnabled(i, enabledFCU[i]);
     }
 
     log();

--- a/src/LSST/M1M3/TS/Settings/Thermal.cpp
+++ b/src/LSST/M1M3/TS/Settings/Thermal.cpp
@@ -21,13 +21,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <cRIO/ThermalILC.h>
-#include <Settings/Thermal.h>
-#include <Events/EnabledILC.h>
-
 #include <algorithm>
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
+
+#include <cRIO/ThermalILC.h>
+
+#include <Events/EnabledILC.h>
+#include <Settings/MixingValve.h>
+#include <Settings/Thermal.h>
 
 using namespace LSST::M1M3::TS::Settings;
 
@@ -44,6 +46,9 @@ void Thermal::load(const std::string &filename) {
                     std::find(disabledIndices.begin(), disabledIndices.end(), i + 1) == disabledIndices.end();
             Events::EnabledILC::instance().setEnabled(i, enabledFCU[i]);
         }
+
+        MixingValve::instance().load(doc["MixingValve"]);
+
     } catch (YAML::Exception &ex) {
         throw std::runtime_error(fmt::format("YAML Loading {}: {}", filename, ex.what()));
     }

--- a/src/LSST/M1M3/TS/Settings/Thermal.h
+++ b/src/LSST/M1M3/TS/Settings/Thermal.h
@@ -24,7 +24,7 @@
 #ifndef _TS_Settings_Thermal_h
 #define _TS_Settings_Thermal_h
 
-#include <string>
+#include <yaml-cpp/yaml.h>
 
 #include <cRIO/Singleton.h>
 #include <TSPublisher.h>
@@ -37,16 +37,18 @@ namespace TS {
 namespace Settings {
 
 /**
- * Thermal Setting class. Loads settings from configuration file and sends
- * settings event.
+ * Thermal settings.
  */
 class Thermal : public cRIO::Singleton<Thermal>, MTM1M3TS_logevent_thermalSettingsC {
 public:
     Thermal(token) {}
 
-    void load(const std::string& filename);
+    void load(YAML::Node doc);
 
     void log() { TSPublisher::SAL()->logEvent_thermalSettings(this, 0); }
+
+    bool autoDisable;
+    int failuresToDisable;
 };
 
 }  // namespace Settings
@@ -54,4 +56,4 @@ public:
 }  // namespace M1M3
 }  // namespace LSST
 
-#endif  //! _TS_Settings_Application_h
+#endif  //! _TS_Settings_Thermal_h

--- a/src/LSST/M1M3/TS/Settings/Thermal.h
+++ b/src/LSST/M1M3/TS/Settings/Thermal.h
@@ -24,12 +24,12 @@
 #ifndef _TS_Settings_Thermal_h
 #define _TS_Settings_Thermal_h
 
-#include <SAL_MTM1M3TS.h>
+#include <string>
 
 #include <cRIO/Singleton.h>
 #include <TSPublisher.h>
 
-#include <string>
+#include <SAL_MTM1M3TS.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/TS/SimulatedFPGA.cpp
+++ b/src/LSST/M1M3/TS/SimulatedFPGA.cpp
@@ -63,7 +63,7 @@ void SimulatedFPGA::writeMPUFIFO(MPU& mpu) {
     }
 }
 
-void SimulatedFPGA::readMPUFIFO(MPU& mpu) {
+std::vector<uint8_t> SimulatedFPGA::readMPUFIFO(MPU& mpu) {
     // TODO shall go away once we have all buffers in uin8_t
     auto mpuResponse = &(_mpuResponses[mpu.getBus()]);
     auto buf = mpuResponse->getBuffer();
@@ -73,6 +73,8 @@ void SimulatedFPGA::readMPUFIFO(MPU& mpu) {
         u8_data[i] = buf[i];
     }
     processMPUResponse(mpu, u8_data, len);
+
+    return std::vector<uint8_t>(u8_data, u8_data + len);
 }
 
 LSST::cRIO::MPUTelemetry SimulatedFPGA::readMPUTelemetry(LSST::cRIO::MPU& mpu) {

--- a/src/LSST/M1M3/TS/SimulatedFPGA.h
+++ b/src/LSST/M1M3/TS/SimulatedFPGA.h
@@ -45,7 +45,7 @@ public:
     void close() override {}
     void finalize() override {}
     void writeMPUFIFO(cRIO::MPU& mpu) override;
-    void readMPUFIFO(cRIO::MPU& mpu) override;
+    std::vector<uint8_t> readMPUFIFO(cRIO::MPU& mpu) override;
     LSST::cRIO::MPUTelemetry readMPUTelemetry(LSST::cRIO::MPU& mpu) override;
     void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) override;

--- a/src/LSST/M1M3/TS/Telemetry/SALMPUFactory.h
+++ b/src/LSST/M1M3/TS/Telemetry/SALMPUFactory.h
@@ -1,5 +1,5 @@
 /*
- * FlowMeter MPU
+ * Interface for factory creating application specific MPU objects.
  *
  * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
  * This product includes software developed by the Vera C.Rubin Observatory Project
@@ -20,44 +20,28 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef __TS_MPU_FLOWMETER__
-#define __TS_MPU_FLOWMETER__
+#ifndef __TS_SALMPUFactory__
+#define __TS_SALMPUFactory__
 
-#include <cRIO/MPU.h>
+#include <MPU/FactoryInterface.h>
+
+#include "FlowMeterSAL.h"
+#include "VFDSAL.h"
 
 namespace LSST {
 namespace M1M3 {
 namespace TS {
+namespace Telemetry {
 
-/**
- * Reads FlowMeter values.
- */
-class FlowMeter : public cRIO::MPU {
+class SALMPUFactory : public FactoryInterface {
 public:
-    FlowMeter(uint8_t bus, uint8_t mpu_address) : MPU(bus, mpu_address) { setLoopTimeOut(1000ms); }
-
-    void loopWrite() override;
-
-    uint16_t getSignalStrength() { return getRegister(5500); }
-    double getFlowRate() { return _getFloatValue(1000); }
-    double getNetTotalizer() { return _getFloatValue(2500); }
-    double getPositiveTotalizer() { return _getFloatValue(2502); }
-    double getNegativeTotalizer() { return _getFloatValue(2504); }
-
-private:
-    float _getFloatValue(uint16_t reg);
-    double _getDoubleValue(uint16_t reg);
+    std::shared_ptr<FlowMeter> createFlowMeter() override { return std::make_shared<FlowMeterSAL>(2, 1); }
+    std::shared_ptr<VFD> createVFD() override { return std::make_shared<VFDSAL>(1, 100); }
 };
 
-class FlowMeterPrint : public FlowMeter {
-public:
-    FlowMeterPrint(uint8_t bus, uint8_t mpu_address) : FlowMeter(bus, mpu_address) {}
-
-    void loopRead(bool timedout) override;
-};
-
+}  // namespace Telemetry
 }  // namespace TS
 }  // namespace M1M3
 }  // namespace LSST
 
-#endif /* __TS_MPU_FLOWMETER__ */
+#endif /* __TS_SALMPUFactory__ */

--- a/src/LSST/M1M3/TS/ThermalFPGA.cpp
+++ b/src/LSST/M1M3/TS/ThermalFPGA.cpp
@@ -87,7 +87,7 @@ void ThermalFPGA::writeMPUFIFO(MPU& mpu) {
                                buf.data(), len, -1, NULL));
 }
 
-void ThermalFPGA::readMPUFIFO(MPU& mpu) {
+std::vector<uint8_t> ThermalFPGA::readMPUFIFO(MPU& mpu) {
     uint8_t req = mpu.getBus() + 10;
     NiThrowError(
             __PRETTY_FUNCTION__,
@@ -95,18 +95,25 @@ void ThermalFPGA::readMPUFIFO(MPU& mpu) {
                                &req, 1, -1, NULL));
 
     uint16_t len;
+
     NiThrowError(
             __PRETTY_FUNCTION__,
             NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_SerialMultiplexResponse,
                               reinterpret_cast<uint8_t*>(&len), 2, 1000, NULL));
     len = ntohs(len);
-    uint8_t data[len];
+    uint8_t* data = new uint8_t[len];
 
     NiThrowError(
             __PRETTY_FUNCTION__,
             NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_SerialMultiplexResponse,
                               data, len, -1, NULL));
     processMPUResponse(mpu, data, len);
+
+    std::vector<uint8_t> ret(data, data + len);
+
+    delete[] data;
+
+    return ret;
 }
 
 LSST::cRIO::MPUTelemetry ThermalFPGA::readMPUTelemetry(MPU& mpu) {

--- a/src/LSST/M1M3/TS/ThermalFPGA.h
+++ b/src/LSST/M1M3/TS/ThermalFPGA.h
@@ -42,7 +42,7 @@ public:
     void close() override;
     void finalize() override;
     void writeMPUFIFO(cRIO::MPU& mpu) override;
-    void readMPUFIFO(cRIO::MPU& mpu) override;
+    std::vector<uint8_t> readMPUFIFO(cRIO::MPU& mpu) override;
     LSST::cRIO::MPUTelemetry readMPUTelemetry(LSST::cRIO::MPU& mpu) override;
     void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) override;

--- a/src/NiFpga/NiFpga_ts_M1M3ThermalFPGA.h
+++ b/src/NiFpga/NiFpga_ts_M1M3ThermalFPGA.h
@@ -23,7 +23,7 @@
 /**
  * The signature of the FPGA bitfile.
  */
-static const char* const NiFpga_ts_M1M3ThermalFPGA_Signature = "39E7F69CF8D3C9456B6B309C81E2FC1D";
+static const char* const NiFpga_ts_M1M3ThermalFPGA_Signature = "3CBD1821559D2404BA9CBF2A52EBA851";
 
 #if NiFpga_Cpp
 extern "C" {

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -97,7 +97,7 @@ public:
 #endif
 
     void writeMPUFIFO(MPU& mpu) override;
-    void readMPUFIFO(MPU& mpu) override;
+    std::vector<uint8_t> readMPUFIFO(MPU& mpu) override;
     void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void readU8ResponseFIFO(uint8_t* data, size_t length, uint32_t timeout) override;
@@ -504,7 +504,7 @@ void PrintTSFPGA::writeMPUFIFO(MPU& mpu) {
     FPGAClass::writeMPUFIFO(mpu);
 }
 
-void PrintTSFPGA::readMPUFIFO(MPU& mpu) { FPGAClass::readMPUFIFO(mpu); }
+std::vector<uint8_t> PrintTSFPGA::readMPUFIFO(MPU& mpu) { return FPGAClass::readMPUFIFO(mpu); }
 
 void PrintTSFPGA::writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) {
     _printBufferU16("C>", true, data, length);

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -41,6 +41,7 @@
 #include <cRIO/FPGACliApp.h>
 #include <cRIO/MPU.h>
 
+#include <MPU/FactoryInterface.h>
 #include <MPU/FlowMeter.h>
 #include <MPU/VFD.h>
 
@@ -114,6 +115,21 @@ private:
     void _printBufferU16(std::string prefix, bool nullTimer, uint16_t* buf, size_t len);
 
     std::chrono::time_point<std::chrono::steady_clock> _cmd_start;
+};
+
+class PrintMPUFactory : public FactoryInterface {
+public:
+    PrintMPUFactory(std::shared_ptr<FlowMeter> flowMeter, std::shared_ptr<VFD> vfd) {
+        _flowMeter = flowMeter;
+        _vfd = vfd;
+    }
+
+    std::shared_ptr<FlowMeter> createFlowMeter() override { return _flowMeter; }
+    std::shared_ptr<VFD> createVFD() override { return _vfd; }
+
+private:
+    std::shared_ptr<FlowMeter> _flowMeter;
+    std::shared_ptr<VFD> _vfd;
 };
 
 #define ILC_ARG "<ILC..>"
@@ -308,7 +324,7 @@ int M1M3TScli::pumpOnOff(command_vec cmds) { return 0; }
 
 FPGA* M1M3TScli::newFPGA(const char* dir) {
     PrintTSFPGA* printFPGA = new PrintTSFPGA();
-    printFPGA->setMPUs(vfd, flowMeter);
+    printFPGA->setMPUFactory(std::make_shared<PrintMPUFactory>(flowMeter, vfd));
     return printFPGA;
 }
 

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -255,14 +255,16 @@ int M1M3TScli::printFlowMeter(command_vec cmds) {
 }
 
 int M1M3TScli::printPump(command_vec cmds) {
+    vfd->clearCommanded();
+
     IFPGA* fpga = dynamic_cast<IFPGA*>(getFPGA());
     if (cmds.size() > 0) {
         if (cmds[0] == "stop") {
-            fpga->coolantPumpStartStop(false);
+            vfd->stop();
         } else if (cmds[0] == "start") {
-            fpga->coolantPumpStartStop(true);
+            vfd->start();
         } else if (cmds[0] == "reset") {
-            fpga->coolantPumpReset();
+            vfd->reset();
         } else if (cmds[0] == "freq") {
             size_t len;
             uint16_t targetFreq = std::stod(cmds[1], &len);
@@ -270,15 +272,13 @@ int M1M3TScli::printPump(command_vec cmds) {
                 std::cerr << "Invalid frequency: " << cmds[1] << std::endl;
                 return 1;
             }
-            fpga->setCoolantPumpFrequency(targetFreq);
+            vfd->setFrequency(targetFreq);
         } else {
             dynamic_cast<IFPGA*>(getFPGA())->setCoolantPumpPower(onOff(cmds[0]));
             std::cout << "Turned pump " << cmds[0] << std::endl;
             return 0;
         }
     }
-
-    vfd->clearCommanded();
 
     while (vfd->getLoopState() != loop_state_t::IDLE) {
         vfd->runLoop(*getFPGA());

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -245,6 +245,8 @@ int M1M3TScli::mpuWrite(command_vec cmds) {
 }
 
 int M1M3TScli::printFlowMeter(command_vec cmds) {
+    flowMeter->clearCommanded();
+
     while (flowMeter->getLoopState() != loop_state_t::IDLE) {
         flowMeter->runLoop(*getFPGA());
     }
@@ -275,6 +277,8 @@ int M1M3TScli::printPump(command_vec cmds) {
             return 0;
         }
     }
+
+    vfd->clearCommanded();
 
     while (vfd->getLoopState() != loop_state_t::IDLE) {
         vfd->runLoop(*getFPGA());

--- a/src/ts-M1M3thermald.cpp
+++ b/src/ts-M1M3thermald.cpp
@@ -52,8 +52,7 @@
 #include <Commands/SAL.h>
 #include <Commands/EnterControl.h>
 #include <SALThermalILC.h>
-#include <Telemetry/FlowMeterSAL.h>
-#include <Telemetry/VFDSAL.h>
+#include <Telemetry/SALMPUFactory.h>
 #include <TSApplication.h>
 #include <TSPublisher.h>
 #include <TSSubscriber.h>
@@ -95,8 +94,7 @@ void M1M3thermald::init() {
 
     TSApplication::instance().setILC(ilc);
 
-    IFPGA::get().setMPUs(std::make_shared<Telemetry::VFDSAL>(1, 100),
-                         std::make_shared<Telemetry::FlowMeterSAL>(2, 1));
+    IFPGA::get().setMPUFactory(std::make_shared<Telemetry::SALMPUFactory>());
 
 #ifdef SIMULATOR
     SPDLOG_WARN("Starting Simulator version! Version {}", VERSION);

--- a/tests/data/MixingValve.yaml
+++ b/tests/data/MixingValve.yaml
@@ -1,9 +1,0 @@
-# units are mA (milliamperes)
-Commanding:
-  FullyClosed: 4
-  FullyOpened: 20
-
-# units are V (Volts)
-PositionFeedback:
-  FullyClosed: 0.03
-  FullyOpened: 9.75

--- a/tests/data/v1/_init.yaml
+++ b/tests/data/v1/_init.yaml
@@ -1,0 +1,21 @@
+FCU:
+  AutoDisable: true
+  FailuresToDisable: 3
+  Disabled: []
+
+FlowMeter:
+  Enabled: true
+
+GlycolPump:
+  Enabled: true
+
+MixingValve:
+  # units are mA (milliamperes)
+  Commanding:
+    FullyClosed: 4
+    FullyOpened: 20
+  
+  # units are V (Volts)
+  PositionFeedback:
+    FullyClosed: 0.03
+    FullyOpened: 9.64

--- a/tests/test_MixingValveSettings.cpp
+++ b/tests/test_MixingValveSettings.cpp
@@ -23,13 +23,29 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
-#include <Settings/MixingValve.h>
+#include <SAL_MTM1M3TS.h>
 
-using namespace LSST::M1M3::TS::Settings;
+#include <cRIO/Settings/Path.h>
+
+#include <Settings/Controller.h>
+#include <Settings/MixingValve.h>
+#include <TSPublisher.h>
+
 using Catch::Approx;
+using namespace LSST::M1M3::TS;
+using namespace LSST::M1M3::TS::Settings;
+
+void init_sal() {
+    std::shared_ptr<SAL_MTM1M3TS> m1m3TSSAL = std::make_shared<SAL_MTM1M3TS>();
+    m1m3TSSAL->setDebugLevel(2);
+    TSPublisher::instance().setSAL(m1m3TSSAL);
+}
 
 TEST_CASE("Test conversions", "[MixingValveSettings]") {
-    REQUIRE_NOTHROW(MixingValve::instance().load("data/MixingValve.yaml"));
+    init_sal();
+
+    LSST::cRIO::Settings::Path::setRootPath("data");
+    REQUIRE_NOTHROW(Controller::instance().load("data/_init.yaml"));
 
     REQUIRE(MixingValve::instance().positionToPercents(10) == 100);
     REQUIRE(MixingValve::instance().positionToPercents(-1) == 0);


### PR DESCRIPTION
- Uses single configuration file
- Enable/disable FlowMeter and GlycolPump, autodisable ILCs
- version history, updated Dockerfile
- Fixed tests
- readMPUFIFO API change
- Call clearCommanded to clear any residual in flow/pump status
- Remove FPGA Punmp functions - those are handled by MPU now
- next MPU to hold commands accepted during MPU processing
- Fixed bitfile, wait commands (100, 101)
