### PR TITLE
DM-42018: report status fields in ILC bitfields

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -7,6 +7,7 @@ Version History
 v0.2.0
 ------
 
+# Report thermal status strings
 * Improved makefile
 
 v0.1.0

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -504,8 +504,8 @@ void M1M3TScli::printTelemetry(const std::string& name, std::shared_ptr<MPU> mpu
 void PrintThermalILC::processThermalStatus(uint8_t address, uint8_t status, float differentialTemperature,
                                            uint8_t fanRPM, float absoluteTemperature) {
     printBusAddress(address);
-    std::cout << "Thermal Status: 0x" << std::setfill('0') << std::setw(2) << std::hex
-              << static_cast<int>(status) << std::endl
+    std::cout << "Thermal ILC Status: 0x" << std::hex << std::setfill('0') << +status << ": "
+              << fmt::format("{}", fmt::join(getStatusString(status), " | ")) << std::endl
               << "Differential Temperature: " << std::to_string(differentialTemperature) << std::endl
               << "Fan RPM: " << std::to_string(fanRPM) << std::endl
               << "Absolute Temperature: " << std::to_string(absoluteTemperature) << std::endl;


### PR DESCRIPTION
- Fixed makefiles, align with ts_vms
- use getStatusString method
- Changed update frequency to 2Hz
- Fixed Update calls frequency
- Fixed makefile - SAL_LIBS
- getThermalStatusString method
- FIxed update times
- Changed CLI commands thermal-xxx to fcu-xx
