### PR TITLE
Align with cRIOcpp changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ts-M1M3thermald
 .isort.cfg
 .mypy.ini
 .ruff.toml
+towncrier.toml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ properties(
 node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
-    def SAME_CRIO_BRANCH = ["main", "tickets/DM-42018"]
+    def SAME_CRIO_BRANCH = ["main", "tickets/DM-41336"]
 
     stage('Cloning sources')
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ properties(
 node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
-    def SAME_CRIO_BRANCH = ["main", "tickets/DM-41336"]
+    def SAME_CRIO_BRANCH = ["main", "tickets/DM-42018"]
 
     stage('Cloning sources')
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ properties(
 node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
-    def SAME_CRIO_BRANCH = ["main", "tickets/DM-41336"]
+    def SAME_CRIO_BRANCH = ["main", "tickets/DM-41336", "tickets/DM-42503"]
 
     stage('Cloning sources')
     {

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ src/libM1M3TS.a: FORCE
 
 ts-M1M3thermald: src/ts-M1M3thermald.cpp.o src/libM1M3TS.a
 	@echo '[LD ] $@'
-	${co}$(CPP) $(LIBS_FLAGS) -o $@ $^  ../ts_cRIOcpp/lib/libcRIOcpp.a $(LIBS) $(SAL_LIBS) $(shell pkg-config --libs readline $(silence))
+	${co}$(CPP) $(LIBS_FLAGS) -o $@ $^  ../ts_cRIOcpp/lib/libcRIOcpp.a $(LIBS) $(SAL_LIBS) $(shell pkg-config --libs readline $(silence)) -lreadline
 
 
 m1m3tscli: src/m1m3tscli.cpp.o src/libM1M3TS.a

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -22,7 +22,7 @@ PKG_CPPFLAGS := \
 
 SAL_CPPFLAGS += $(PKG_CPPFLAGS) \
 	-I${OSPL_HOME}/include -I${OSPL_HOME}/include/sys -I${OSPL_HOME}/include/dcps/C++/SACPP \
-	-I${SAL_WORK_DIR}/MTM1M3/cpp/src -I${SAL_WORK_DIR}/MTMount/cpp/src -I${SAL_WORK_DIR}/include \
+	-I${SAL_WORK_DIR}/MTM1M3TS/cpp/src -I${SAL_WORK_DIR}/include \
 	-I${SAL_HOME}/include -I${LSST_SDK_INSTALL}/include
 
 PKG_LIBS := \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -41,7 +41,9 @@ else
   PKG_LIBS += $(shell pkg-config spdlog --libs $(silence) | sed -E 's/-l([a-z0-9]*)/-l:lib\1.a/g')
 endif
 
-LIBS += $(PKG_LIBS) -ldl -ldcpssacpp -ldcpsgapi -lddsuser -lddskernel \
+LIBS += $(PKG_LIBS) -ldl
+
+SAL_LIBS := -ldcpssacpp -ldcpsgapi -lddsuser -lddskernel \
 	-lpthread -lddsserialization -lddsconfparser -lddsconf -lddsdatabase \
 	-lddsutil -lddsos \
 	${SAL_WORK_DIR}/lib/libSAL_MTM1M3TS.a

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -8,6 +8,7 @@ v0.2.0
 ------
 
 # Report thermal status strings
+* Reports meaning of ILC status bites
 * Improved makefile
 
 v0.1.0

--- a/src/LSST/M1M3/TS/Commands/EnterControl.h
+++ b/src/LSST/M1M3/TS/Commands/EnterControl.h
@@ -37,7 +37,7 @@ namespace Commands {
 
 class EnterControl : public cRIO::Task {
 public:
-    std::chrono::milliseconds run() override {
+    cRIO::task_return_t run() override {
         SPDLOG_DEBUG("EnterControl");
         TSPublisher::instance().logSoftwareVersions();
         TSPublisher::instance().logSimulationMode();

--- a/src/LSST/M1M3/TS/Commands/EnterControl.h
+++ b/src/LSST/M1M3/TS/Commands/EnterControl.h
@@ -23,10 +23,11 @@
 #ifndef _TS_Command_EnterControl_
 #define _TS_Command_ENterControl_
 
-#include <cRIO/Command.h>
 #include <SAL_MTM1M3TS.h>
-#include <TSPublisher.h>
 
+#include <cRIO/Task.h>
+
+#include <TSPublisher.h>
 #include <Events/SummaryState.h>
 
 namespace LSST {
@@ -34,13 +35,14 @@ namespace M1M3 {
 namespace TS {
 namespace Commands {
 
-class EnterControl : public cRIO::Command {
+class EnterControl : public cRIO::Task {
 public:
-    void execute() override {
+    std::chrono::milliseconds run() override {
         SPDLOG_DEBUG("EnterControl");
         TSPublisher::instance().logSoftwareVersions();
         TSPublisher::instance().logSimulationMode();
         Events::SummaryState::setState(MTM1M3TS::MTM1M3TS_shared_SummaryStates_StandbyState);
+        return Task::DONT_RESCHEDULE;
     }
 };
 

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -142,7 +142,8 @@ void SAL_heaterFanDemand::execute() {
         TSApplication::ilc()->clear();
 
         TSApplication::instance().callFunctionOnIlcs([this](uint8_t address) -> void {
-            TSApplication::ilc()->setThermalDemand(address, params.heaterPWM[address - 1], params.fanRPM[address - 1]);
+            TSApplication::ilc()->setThermalDemand(address, params.heaterPWM[address - 1],
+                                                   params.fanRPM[address - 1]);
         });
 
         IFPGA::get().ilcCommands(*TSApplication::ilc(), 1000);

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -46,7 +46,7 @@ void changeAllILCsMode(uint16_t mode) {
     TSApplication::instance().callFunctionOnIlcs(
             [mode](uint8_t address) -> void { TSApplication::ilc()->changeILCMode(address, mode); });
 
-    IFPGA::get().ilcCommands(*TSApplication::ilc());
+    IFPGA::get().ilcCommands(*TSApplication::ilc(), 1000);
 }
 
 bool SAL_start::validate() {
@@ -75,7 +75,7 @@ void SAL_start::execute() {
     TSApplication::instance().callFunctionOnIlcs(
             [](uint8_t address) -> void { TSApplication::ilc()->reportServerID(address); });
 
-    IFPGA::get().ilcCommands(*TSApplication::ilc());
+    IFPGA::get().ilcCommands(*TSApplication::ilc(), 1000);
 
     Events::ThermalInfo::instance().log();
 
@@ -141,7 +141,7 @@ void SAL_heaterFanDemand::execute() {
     for (int i = 0; i < NUM_TS_ILC; i++) {
         TSApplication::ilc()->setThermalDemand(i + 1, params.heaterPWM[i], params.fanRPM[i]);
     }
-    IFPGA::get().ilcCommands(*TSApplication::ilc());
+    IFPGA::get().ilcCommands(*TSApplication::ilc(), 1000);
     ackComplete();
     SPDLOG_INFO("Changed heaters and fans demand");
 }

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -138,6 +138,8 @@ void SAL_fanCoilsHeatersPower::execute() {
 bool SAL_heaterFanDemand::validate() { return Events::EngineeringMode::instance().isEnabled(); }
 
 void SAL_heaterFanDemand::execute() {
+    TSApplication::ilc()->clear();
+
     for (int i = 0; i < NUM_TS_ILC; i++) {
         TSApplication::ilc()->setThermalDemand(i + 1, params.heaterPWM[i], params.fanRPM[i]);
     }

--- a/src/LSST/M1M3/TS/Commands/SAL.cpp
+++ b/src/LSST/M1M3/TS/Commands/SAL.cpp
@@ -131,7 +131,6 @@ void SAL_setEngineeringMode::execute() {
 bool SAL_heaterFanDemand::validate() { return Events::EngineeringMode::instance().isEnabled(); }
 
 void SAL_heaterFanDemand::execute() {
-    TSApplication::ilc()->clear();
     TSApplication::ilc()->broadcastThermalDemand(params.heaterPWM, params.fanRPM);
     IFPGA::get().ilcCommands(*TSApplication::ilc());
     ackComplete();

--- a/src/LSST/M1M3/TS/Commands/SAL.h
+++ b/src/LSST/M1M3/TS/Commands/SAL.h
@@ -46,6 +46,8 @@ SAL_COMMAND_CLASS(MTM1M3TS, TSPublisher::SAL(), exitControl);
 
 SAL_COMMAND_CLASS_validate(MTM1M3TS, TSPublisher::SAL(), setEngineeringMode);
 
+SAL_COMMAND_CLASS_validate(MTM1M3TS, TSPublisher::SAL(), fanCoilsHeatersPower);
+
 SAL_COMMAND_CLASS_validate(MTM1M3TS, TSPublisher::SAL(), heaterFanDemand);
 
 SAL_COMMAND_CLASS_validate(MTM1M3TS, TSPublisher::SAL(), setMixingValve);

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -48,7 +48,7 @@ using namespace std::chrono_literals;
 
 constexpr auto default_period = 500ms;
 
-std::chrono::milliseconds Update::run() {
+LSST::cRIO::task_return_t Update::run() {
     SPDLOG_TRACE("Commands::Update execute");
 
     _sendFCU();

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -20,6 +20,8 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
 #include <spdlog/spdlog.h>
 
 #include <cRIO/ThermalILC.h>
@@ -42,6 +44,7 @@
 #include "TSApplication.h"
 
 using namespace LSST::M1M3::TS::Commands;
+using namespace std::chrono_literals;
 
 void Update::execute() {
     SPDLOG_TRACE("Commands::Update execute");
@@ -85,6 +88,14 @@ void Update::_sendMixingValve() {
 }
 
 void Update::_sendFCU() {
+    static auto next_update = std::chrono::steady_clock::now() - 20ms;
+
+    auto now = std::chrono::steady_clock::now();
+    if (now < next_update) {
+        return;
+    }
+    next_update = now + 500ms;
+
     try {
         TSApplication::ilc()->clear();
 

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -48,7 +48,7 @@ using namespace std::chrono_literals;
 
 constexpr auto default_period = 500ms;
 
-void Update::execute() {
+std::chrono::milliseconds Update::run() {
     SPDLOG_TRACE("Commands::Update execute");
 
     _sendFCU();
@@ -69,6 +69,8 @@ void Update::execute() {
     }
 
     SPDLOG_TRACE("Commands::Update leaving execute");
+
+    return Task::DONT_RESCHEDULE;
 }
 
 void Update::_sendGlycolLoopTemperature() {

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -87,14 +87,18 @@ void Update::_sendMixingValve() {
     }
 }
 
-static auto next_update = std::chrono::steady_clock::now() - 20ms;
-
 void Update::_sendFCU() {
+    static auto next_update = std::chrono::steady_clock::now() - 20ms;
+
     auto now = std::chrono::steady_clock::now();
     if (now < next_update) {
         return;
     }
-    next_update += 500ms;
+    if (now - next_update > 100ms) {
+        next_update = now + 500ms;
+    } else {
+        next_update += 500ms;
+    }
 
     try {
         TSApplication::ilc()->clear();

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -125,7 +125,7 @@ void Update::_sendFCU() {
             }
         });
 
-        IFPGA::get().ilcCommands(*TSApplication::ilc());
+        IFPGA::get().ilcCommands(*TSApplication::ilc(), 400);
 
         Telemetry::ThermalData::instance().send();
     } catch (std::exception &e) {

--- a/src/LSST/M1M3/TS/Commands/Update.cpp
+++ b/src/LSST/M1M3/TS/Commands/Update.cpp
@@ -87,14 +87,14 @@ void Update::_sendMixingValve() {
     }
 }
 
-void Update::_sendFCU() {
-    static auto next_update = std::chrono::steady_clock::now() - 20ms;
+static auto next_update = std::chrono::steady_clock::now() - 20ms;
 
+void Update::_sendFCU() {
     auto now = std::chrono::steady_clock::now();
     if (now < next_update) {
         return;
     }
-    next_update = now + 500ms;
+    next_update += 500ms;
 
     try {
         TSApplication::ilc()->clear();

--- a/src/LSST/M1M3/TS/Commands/Update.h
+++ b/src/LSST/M1M3/TS/Commands/Update.h
@@ -23,8 +23,6 @@
 #ifndef _TS_Command_Update_
 #define _TS_Command_Update_
 
-#include <chrono>
-
 #include <SAL_MTM1M3TS.h>
 
 #include <cRIO/Task.h>
@@ -36,7 +34,7 @@ namespace Commands {
 
 class Update : public cRIO::Task {
 public:
-    std::chrono::milliseconds run() override;
+    cRIO::task_return_t run() override;
 
 private:
     void _sendGlycolLoopTemperature();

--- a/src/LSST/M1M3/TS/Commands/Update.h
+++ b/src/LSST/M1M3/TS/Commands/Update.h
@@ -26,16 +26,17 @@
 #include <chrono>
 
 #include <SAL_MTM1M3TS.h>
-#include <cRIO/Command.h>
+
+#include <cRIO/Task.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace TS {
 namespace Commands {
 
-class Update : public cRIO::Command {
+class Update : public cRIO::Task {
 public:
-    void execute() override;
+    std::chrono::milliseconds run() override;
 
 private:
     void _sendGlycolLoopTemperature();

--- a/src/LSST/M1M3/TS/IFPGA.cpp
+++ b/src/LSST/M1M3/TS/IFPGA.cpp
@@ -113,9 +113,9 @@ void IFPGA::setHeartbeat(bool heartbeat) {
 }
 
 void IFPGA::processMPUResponse(LSST::cRIO::MPU& mpu, uint8_t* data, uint16_t len) {
-    uint16_t u16_data[len];
+    std::vector<uint16_t> u16_data(len);
     for (int i = 0; i < len; i++) {
         u16_data[i] = data[i];
     }
-    mpu.processResponse(u16_data, len);
+    mpu.processResponse(u16_data.data(), len);
 }

--- a/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
+++ b/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
@@ -34,7 +34,7 @@ using namespace LSST::M1M3::TS;
 void OuterLoopClockThread::run(std::unique_lock<std::mutex>& lock) {
     SPDLOG_INFO("OuterLoopClockThread: Run");
     while (keepRunning) {
-        runCondition.wait_for(lock, 20ms);
+        runCondition.wait_for(lock, 500ms);
         if (Events::SummaryState::instance().active()) {
             cRIO::ControllerThread::instance().enqueue(new Commands::Update());
         }

--- a/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
+++ b/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
@@ -20,21 +20,23 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
+#include <spdlog/spdlog.h>
+
 #include <cRIO/ControllerThread.h>
 #include <OuterLoopClockThread.h>
 #include <Commands/Update.h>
 #include <Events/SummaryState.h>
-
-#include <chrono>
-#include <spdlog/spdlog.h>
 
 using namespace std::chrono_literals;
 using namespace LSST::M1M3::TS;
 
 void OuterLoopClockThread::run(std::unique_lock<std::mutex>& lock) {
     SPDLOG_INFO("OuterLoopClockThread: Run");
+
     while (keepRunning) {
-        runCondition.wait_for(lock, 500ms);
+        runCondition.wait_for(lock, 20ms);
         if (Events::SummaryState::instance().active()) {
             cRIO::ControllerThread::instance().enqueue(new Commands::Update());
         }

--- a/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
+++ b/src/LSST/M1M3/TS/OuterLoopClockThread.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <chrono>
+#include <memory>
 
 #include <spdlog/spdlog.h>
 
@@ -38,7 +39,7 @@ void OuterLoopClockThread::run(std::unique_lock<std::mutex>& lock) {
     while (keepRunning) {
         runCondition.wait_for(lock, 20ms);
         if (Events::SummaryState::instance().active()) {
-            cRIO::ControllerThread::instance().enqueue(new Commands::Update());
+            cRIO::ControllerThread::instance().enqueue(std::make_shared<Commands::Update>());
         }
     }
     SPDLOG_INFO("OuterLoopClockThread: Completed");

--- a/src/LSST/M1M3/TS/SimulatedFPGA.cpp
+++ b/src/LSST/M1M3/TS/SimulatedFPGA.cpp
@@ -68,13 +68,13 @@ std::vector<uint8_t> SimulatedFPGA::readMPUFIFO(MPU& mpu) {
     auto mpuResponse = &(_mpuResponses[mpu.getBus()]);
     auto buf = mpuResponse->getBuffer();
     auto len = mpuResponse->getLength();
-    uint8_t u8_data[len];
-    for (int i = 0; i < len; i++) {
+    std::vector<uint8_t> u8_data(len);
+    for (size_t i = 0; i < len; i++) {
         u8_data[i] = buf[i];
     }
-    processMPUResponse(mpu, u8_data, len);
+    processMPUResponse(mpu, u8_data.data(), len);
 
-    return std::vector<uint8_t>(u8_data, u8_data + len);
+    return u8_data;
 }
 
 LSST::cRIO::MPUTelemetry SimulatedFPGA::readMPUTelemetry(LSST::cRIO::MPU& mpu) {
@@ -359,11 +359,11 @@ void SimulatedFPGA::_simulateModbus(uint16_t* data, size_t length) {
 }
 
 void SimulatedFPGA::_simulateMPU(MPU& mpu, uint8_t* data, size_t length) {
-    uint16_t u16_data[length];
+    std::vector<uint16_t> u16_data(length);
     for (size_t i = 0; i < length; i++) {
         u16_data[i] = data[i];
     }
-    SimulatedMPU buf(u16_data, length);
+    SimulatedMPU buf(u16_data.data(), length);
     while (!buf.endOfBuffer()) {
         uint8_t address = buf.read<uint8_t>();
         uint8_t func = buf.read<uint8_t>();

--- a/src/LSST/M1M3/TS/TSSubscriber.cpp
+++ b/src/LSST/M1M3/TS/TSSubscriber.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <chrono>
+#include <memory>
 
 #include <spdlog/spdlog.h>
 
@@ -39,12 +40,13 @@ constexpr int32_t ACK_COMPLETE = 303;    /// Command is completed.
 constexpr int32_t ACK_FAILED = -302;     /// Command execution failed.
 
 TSSubscriber::TSSubscriber(std::shared_ptr<SAL_MTM1M3TS> m1m3tsSAL) {
-#define ADD_SAL_COMMAND(name)                                                                   \
-    _commands[#name] = [m1m3tsSAL]() {                                                          \
-        MTM1M3TS_command_##name##C data;                                                        \
-        int32_t commandID = m1m3tsSAL->acceptCommand_##name(&data);                             \
-        if (commandID <= 0) return;                                                             \
-        cRIO::ControllerThread::instance().enqueue(new Commands::SAL_##name(commandID, &data)); \
+#define ADD_SAL_COMMAND(name)                                              \
+    _commands[#name] = [m1m3tsSAL]() {                                     \
+        MTM1M3TS_command_##name##C data;                                   \
+        int32_t commandID = m1m3tsSAL->acceptCommand_##name(&data);        \
+        if (commandID <= 0) return;                                        \
+        cRIO::ControllerThread::instance().enqueue(                        \
+                std::make_shared<Commands::SAL_##name>(commandID, &data)); \
     }
 
     ADD_SAL_COMMAND(start);

--- a/src/LSST/M1M3/TS/TSSubscriber.cpp
+++ b/src/LSST/M1M3/TS/TSSubscriber.cpp
@@ -20,15 +20,17 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
+#include <spdlog/spdlog.h>
+
+#include <SAL_MTM1M3TS.h>
+
 #include <TSSubscriber.h>
 #include <Commands/SAL.h>
 
 #include <cRIO/Command.h>
 #include <cRIO/ControllerThread.h>
-#include <SAL_MTM1M3TS.h>
-#include <spdlog/spdlog.h>
-
-#include <chrono>
 
 using namespace LSST::M1M3::TS;
 
@@ -51,6 +53,7 @@ TSSubscriber::TSSubscriber(std::shared_ptr<SAL_MTM1M3TS> m1m3tsSAL) {
     ADD_SAL_COMMAND(standby);
     ADD_SAL_COMMAND(exitControl);
     ADD_SAL_COMMAND(setEngineeringMode);
+    ADD_SAL_COMMAND(fanCoilsHeatersPower);
     ADD_SAL_COMMAND(heaterFanDemand);
     ADD_SAL_COMMAND(setMixingValve);
     ADD_SAL_COMMAND(coolantPumpPower);

--- a/src/LSST/M1M3/TS/Telemetry/ThermalData.cpp
+++ b/src/LSST/M1M3/TS/Telemetry/ThermalData.cpp
@@ -55,6 +55,8 @@ void ThermalData::update(uint8_t address, uint8_t _status, float _differentialTe
 }
 
 void ThermalData::send() {
+    timestamp = TSPublisher::instance().getTimestamp();
+
     salReturn ret = TSPublisher::SAL()->putSample_thermalData(this);
     if (ret != SAL__OK) {
         SPDLOG_WARN("Cannot send thermalData: {}", ret);

--- a/src/LSST/M1M3/TS/ThermalFPGA.cpp
+++ b/src/LSST/M1M3/TS/ThermalFPGA.cpp
@@ -71,8 +71,12 @@ void ThermalFPGA::finalize() {
 
 void ThermalFPGA::writeMPUFIFO(MPU& mpu) {
     auto buf = mpu.getCommandVector();
+
     uint8_t bus = mpu.getBus();
     uint8_t len = buf.size();
+
+    writeDebugFile<uint8_t> ("MPU<", buf.data(), len);
+
     NiThrowError(
             __PRETTY_FUNCTION__,
             NiFpga_WriteFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU8_SerialMultiplexRequest,
@@ -107,6 +111,9 @@ std::vector<uint8_t> ThermalFPGA::readMPUFIFO(MPU& mpu) {
             __PRETTY_FUNCTION__,
             NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_SerialMultiplexResponse,
                               data, len, -1, NULL));
+
+    writeDebugFile<uint8_t> ("MPU>", data, len);
+
     processMPUResponse(mpu, data, len);
 
     std::vector<uint8_t> ret(data, data + len);
@@ -172,12 +179,16 @@ void ThermalFPGA::writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeo
     NiThrowError(__PRETTY_FUNCTION__,
                  NiFpga_WriteFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU16_CommandFIFO,
                                      data, length, timeout, NULL));
+    
+    writeDebugFile<uint16_t> ("CMD<", data, length);
 }
 
 void ThermalFPGA::writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) {
     NiThrowError(__PRETTY_FUNCTION__,
                  NiFpga_WriteFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU16_RequestFIFO,
                                      data, length, timeout, NULL));
+
+    writeDebugFile<uint16_t> ("REQ<", data, length);
 }
 
 void ThermalFPGA::readSGLResponseFIFO(float* data, size_t length, uint32_t timeout) {
@@ -190,12 +201,16 @@ void ThermalFPGA::readU8ResponseFIFO(uint8_t* data, size_t length, uint32_t time
     NiThrowError(__PRETTY_FUNCTION__,
                  NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_U8ResponseFIFO,
                                    data, length, timeout, NULL));
+
+    writeDebugFile<uint8_t> ("U8>", data, length);
 }
 
 void ThermalFPGA::readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t timeout) {
     NiThrowError(__PRETTY_FUNCTION__,
                  NiFpga_ReadFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU16_U16ResponseFIFO,
                                     data, length, timeout, NULL));
+
+    writeDebugFile<uint16_t> ("U16>", data, length);
 }
 
 float ThermalFPGA::chassisTemperature() {

--- a/src/LSST/M1M3/TS/ThermalFPGA.cpp
+++ b/src/LSST/M1M3/TS/ThermalFPGA.cpp
@@ -75,7 +75,7 @@ void ThermalFPGA::writeMPUFIFO(MPU& mpu) {
     uint8_t bus = mpu.getBus();
     uint8_t len = buf.size();
 
-    writeDebugFile<uint8_t> ("MPU<", buf.data(), len);
+    writeDebugFile<uint8_t>("MPU<", buf.data(), len);
 
     NiThrowError(
             __PRETTY_FUNCTION__,
@@ -112,7 +112,7 @@ std::vector<uint8_t> ThermalFPGA::readMPUFIFO(MPU& mpu) {
             NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_SerialMultiplexResponse,
                               data, len, -1, NULL));
 
-    writeDebugFile<uint8_t> ("MPU>", data, len);
+    writeDebugFile<uint8_t>("MPU>", data, len);
 
     processMPUResponse(mpu, data, len);
 
@@ -129,8 +129,6 @@ LSST::cRIO::MPUTelemetry ThermalFPGA::readMPUTelemetry(MPU& mpu) {
             __PRETTY_FUNCTION__,
             NiFpga_WriteFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU8_SerialMultiplexRequest,
                                req, 4, -1, NULL));
-
-    std::vector<uint8_t> buffer;
 
     bool timedout;
 
@@ -154,16 +152,12 @@ LSST::cRIO::MPUTelemetry ThermalFPGA::readMPUTelemetry(MPU& mpu) {
                               reinterpret_cast<uint8_t*>(&len), 2, 1, NULL));
 
     len = ntohs(len);
-    uint8_t data[len];
+    std::vector<uint8_t> buffer(len);
 
     NiThrowError(
             __PRETTY_FUNCTION__,
             NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_SerialMultiplexResponse,
-                              data, len, 10, NULL));
-
-    for (int i = 0; i < len; i++) {
-        buffer.push_back(data[i]);
-    }
+                              buffer.data(), len, 10, NULL));
 
     ackIrqs(irq);
 
@@ -179,8 +173,8 @@ void ThermalFPGA::writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeo
     NiThrowError(__PRETTY_FUNCTION__,
                  NiFpga_WriteFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU16_CommandFIFO,
                                      data, length, timeout, NULL));
-    
-    writeDebugFile<uint16_t> ("CMD<", data, length);
+
+    writeDebugFile<uint16_t>("CMD<", data, length);
 }
 
 void ThermalFPGA::writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) {
@@ -188,7 +182,7 @@ void ThermalFPGA::writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeo
                  NiFpga_WriteFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_HostToTargetFifoU16_RequestFIFO,
                                      data, length, timeout, NULL));
 
-    writeDebugFile<uint16_t> ("REQ<", data, length);
+    writeDebugFile<uint16_t>("REQ<", data, length);
 }
 
 void ThermalFPGA::readSGLResponseFIFO(float* data, size_t length, uint32_t timeout) {
@@ -202,7 +196,7 @@ void ThermalFPGA::readU8ResponseFIFO(uint8_t* data, size_t length, uint32_t time
                  NiFpga_ReadFifoU8(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU8_U8ResponseFIFO,
                                    data, length, timeout, NULL));
 
-    writeDebugFile<uint8_t> ("U8>", data, length);
+    writeDebugFile<uint8_t>("U8>", data, length);
 }
 
 void ThermalFPGA::readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t timeout) {
@@ -210,7 +204,7 @@ void ThermalFPGA::readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t ti
                  NiFpga_ReadFifoU16(_session, NiFpga_ts_M1M3ThermalFPGA_TargetToHostFifoU16_U16ResponseFIFO,
                                     data, length, timeout, NULL));
 
-    writeDebugFile<uint16_t> ("U16>", data, length);
+    writeDebugFile<uint16_t>("U16>", data, length);
 }
 
 float ThermalFPGA::chassisTemperature() {

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -20,14 +20,6 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifdef SIMULATOR
-#include <SimulatedFPGA.h>
-#define FPGAClass SimulatedFPGA
-#else
-#include <ThermalFPGA.h>
-#define FPGAClass ThermalFPGA
-#endif
-
 #include <iostream>
 #include <iomanip>
 #include <memory>
@@ -40,6 +32,14 @@
 #include <cRIO/PrintILC.h>
 #include <cRIO/FPGACliApp.h>
 #include <cRIO/MPU.h>
+
+#ifdef SIMULATOR
+#include <SimulatedFPGA.h>
+#define FPGAClass SimulatedFPGA
+#else
+#include <ThermalFPGA.h>
+#define FPGAClass ThermalFPGA
+#endif
 
 #include <MPU/FactoryInterface.h>
 #include <MPU/FlowMeter.h>
@@ -190,6 +190,10 @@ M1M3TScli::M1M3TScli(const char* name, const char* description) : FPGACliApp(nam
 
     vfd = std::make_shared<VFDPrint>(1, 100);
     addMPU("vfd", vfd);
+
+#ifdef SIMULATOR
+    std::cout << "Starting SIMULATED m1m3tscli!" << std::endl;
+#endif
 }
 
 int M1M3TScli::mpuRead(command_vec cmds) {

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -61,7 +61,7 @@ public:
     int mixingValve(command_vec cmds);
     int fcuOnOff(command_vec cmds);
     int pumpOnOff(command_vec cmds);
-    int thermalDemand(command_vec cmds);
+    int fcuDemand(command_vec cmds);
     int setReHeaterGain(command_vec cmds);
     int chassisTemperature(command_vec cmds);
     int glycolTemperature(command_vec cmds);
@@ -150,13 +150,13 @@ M1M3TScli::M1M3TScli(const char* name, const char* description) : FPGACliApp(nam
     addCommand("pump", std::bind(&M1M3TScli::printPump, this, std::placeholders::_1), "s?", NEED_FPGA, NULL,
                "Turns pump on and reads Pump VFD values");
 
-    addCommand("thermal-demand", std::bind(&M1M3TScli::thermalDemand, this, std::placeholders::_1), "iis?",
+    addCommand("fcu-demand", std::bind(&M1M3TScli::fcuDemand, this, std::placeholders::_1), "iis?",
                NEED_FPGA, "<heater PWM> <fan RPM> " ILC_ARG, "Sets FCU heater and fan");
     addCommand("slot4", std::bind(&M1M3TScli::slot4, this, std::placeholders::_1), "", NEED_FPGA, NULL,
                "Reads slot 4 inputs");
 
     addILCCommand(
-            "thermal-status",
+            "fcu-status",
             [](ILCUnit u) {
                 std::dynamic_pointer_cast<PrintThermalILC>(u.first)->reportThermalStatus(u.second);
             },
@@ -328,7 +328,7 @@ FPGA* M1M3TScli::newFPGA(const char* dir) {
     return printFPGA;
 }
 
-int M1M3TScli::thermalDemand(command_vec cmds) {
+int M1M3TScli::fcuDemand(command_vec cmds) {
     uint8_t heater = std::stoi(cmds[0]);
     uint8_t fan = std::stoi(cmds[1]);
     cmds.erase(cmds.begin(), cmds.begin() + 2);

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -290,14 +290,14 @@ int M1M3TScli::printPump(command_vec cmds) {
             }
             vfd->setFrequency(targetFreq);
         } else {
-            dynamic_cast<IFPGA*>(getFPGA())->setCoolantPumpPower(onOff(cmds[0]));
+            fpga->setCoolantPumpPower(onOff(cmds[0]));
             std::cout << "Turned pump " << cmds[0] << std::endl;
             return 0;
         }
     }
 
     while (vfd->getLoopState() != loop_state_t::IDLE) {
-        vfd->runLoop(*getFPGA());
+        vfd->runLoop(*fpga);
     }
 
     return 0;
@@ -504,7 +504,7 @@ void M1M3TScli::printTelemetry(const std::string& name, std::shared_ptr<MPU> mpu
 void PrintThermalILC::processThermalStatus(uint8_t address, uint8_t status, float differentialTemperature,
                                            uint8_t fanRPM, float absoluteTemperature) {
     printBusAddress(address);
-    std::cout << "Thermal ILC Status: 0x" << std::hex << std::setfill('0') << +status << ": "
+    std::cout << "Thermal ILC Status: 0x" << std::hex << std::setfill('0') << std::setw(4) << +status << ": "
               << fmt::format("{}", fmt::join(getStatusString(status), " | ")) << std::endl
               << "Differential Temperature: " << std::to_string(differentialTemperature) << std::endl
               << "Fan RPM: " << std::to_string(fanRPM) << std::endl

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -343,7 +343,7 @@ int M1M3TScli::fcuBroadcast(command_vec cmds) {
     memset(fan_data, fan, NUM_TS_ILC);
 
     std::dynamic_pointer_cast<PrintThermalILC>(getILC(0))->broadcastThermalDemand(heater_data, fan_data);
-    getFPGA()->ilcCommands(*getILC(0));
+    getFPGA()->ilcCommands(*getILC(0), ilcTimeout);
     return 0;
 }
 
@@ -357,7 +357,7 @@ int M1M3TScli::fcuDemand(command_vec cmds) {
     for (auto u : ilcs) {
         std::dynamic_pointer_cast<PrintThermalILC>(u.first)->setThermalDemand(u.second, heater, fan);
     }
-    getFPGA()->ilcCommands(*getILC(0));
+    getFPGA()->ilcCommands(*getILC(0), ilcTimeout);
     return 0;
 }
 
@@ -372,7 +372,7 @@ int M1M3TScli::setReHeaterGain(command_vec cmds) {
         std::dynamic_pointer_cast<PrintThermalILC>(u.first)->setReHeaterGains(u.second, proportionalGain,
                                                                               integralGain);
     }
-    getFPGA()->ilcCommands(*getILC(0));
+    getFPGA()->ilcCommands(*getILC(0), ilcTimeout);
     return 0;
 }
 

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -505,7 +505,7 @@ void PrintThermalILC::processThermalStatus(uint8_t address, uint8_t status, floa
                                            uint8_t fanRPM, float absoluteTemperature) {
     printBusAddress(address);
     std::cout << "Thermal ILC Status: 0x" << std::hex << std::setfill('0') << std::setw(4) << +status << ": "
-              << fmt::format("{}", fmt::join(getStatusString(status), " | ")) << std::endl
+              << fmt::format("{}", fmt::join(getThermalStatusString(status), " | ")) << std::endl
               << "Differential Temperature: " << std::to_string(differentialTemperature) << std::endl
               << "Fan RPM: " << std::to_string(fanRPM) << std::endl
               << "Absolute Temperature: " << std::to_string(absoluteTemperature) << std::endl;

--- a/src/m1m3tscli.cpp
+++ b/src/m1m3tscli.cpp
@@ -412,11 +412,11 @@ int M1M3TScli::glycolDebug(command_vec) {
         dynamic_cast<IFPGA*>(getFPGA())->readU8ResponseFIFO(reinterpret_cast<uint8_t*>(&len), 2, 150);
         len = ntohs(len);
         if (len > 0) {
-            uint8_t data[len + 1];
-            dynamic_cast<IFPGA*>(getFPGA())->readU8ResponseFIFO(data, len, 10);
+            std::vector<uint8_t> data(len + 1);
+            dynamic_cast<IFPGA*>(getFPGA())->readU8ResponseFIFO(data.data(), len, 10);
 
             data[len] = '\0';
-            std::cout << "String out: " << data << std::endl;
+            std::cout << "String out: " << data.data() << std::endl;
         }
     };
 

--- a/src/ts-M1M3thermald.cpp
+++ b/src/ts-M1M3thermald.cpp
@@ -113,7 +113,7 @@ void M1M3thermald::init() {
     SPDLOG_INFO("Creating subscriber");
     addThread(new TSSubscriber(_m1m3tsSAL));
 
-    LSST::cRIO::ControllerThread::instance().enqueue(new Commands::EnterControl());
+    LSST::cRIO::ControllerThread::instance().enqueue(std::make_shared<Commands::EnterControl>());
 
     daemonOK();
 }

--- a/tests/test_SimulatedFPGA.cpp
+++ b/tests/test_SimulatedFPGA.cpp
@@ -87,5 +87,5 @@ TEST_CASE("Test simulated FPGA responses", "[SimulatedFPGA]") {
 
     testILC.reportServerID(16);
 
-    simulated.ilcCommands(testILC);
+    simulated.ilcCommands(testILC, 10);
 }


### PR DESCRIPTION
- use getStatusString method
- Changed update frequency to 2Hz
- Fixed Update calls frequency
- Fixed makefile - SAL_LIBS
- getThermalStatusString method
- FIxed update times
- Changed CLI commands thermal-xxx to fcu-xx, updated version-history.rst
- fcu-broadcast command
- fcu-broadcast command
- Send thermal demand (command 88) as individual, not broadcast
- FPGA debugging
- Clear ILCs before sending command
- Fix FCU readouts
- Use Tasks from cRIOcpp
- Fix simulator compilation
